### PR TITLE
close #76 セッション処理の追加

### DIFF
--- a/index/common/user_session.php
+++ b/index/common/user_session.php
@@ -1,12 +1,16 @@
 <?php
-    # セッションに関する関数
+    # セッションに関する関数群
+
+    #定数定義
+    define("ONEHOUR", 3600);
+    define("PAST", time()-42000);
 
     # 制作者:towa1204
-    # 更新日:2021/5/27
+    # 更新日:2021/6/26
     # 機能:セッションの開始とセッションタイムアウトのチェックを行う
     function user_session_start() {
         session_start();
-        if (isset($_SESSION["last_activity"]) && (time() - $_SESSION["last_activity"] > 3600)) {
+        if (isset($_SESSION["last_activity"]) && (time() - $_SESSION["last_activity"] > ONEHOUR)) {
             # 最後にアクセスしてから1時間経過したとき
             # セッション変数の初期化
             $_SESSION = array();
@@ -31,7 +35,7 @@
     }
 
     # 制作者:towa1204
-    # 更新日:2021/5/27
+    # 更新日:2021/6/26
     # 機能:全ユーザのログアウトを行う
     function session_logout() {
         session_start();
@@ -41,7 +45,7 @@
         # セッションクッキーを削除
         if (ini_get("session.use_cookies")) {
             $params = session_get_cookie_params();
-            setcookie(session_name(), '', time() - 42000,
+            setcookie(session_name(), '', PAST,
                 $params["path"], $params["domain"],
                 $params["secure"], $params["httponly"]
             );

--- a/index/common/user_session.php
+++ b/index/common/user_session.php
@@ -1,0 +1,53 @@
+<?php
+    # セッションに関する関数
+
+    # 制作者:towa1204
+    # 更新日:2021/5/27
+    # 機能:セッションの開始とセッションタイムアウトのチェックを行う
+    function user_session_start() {
+        session_start();
+        if (isset($_SESSION["last_activity"]) && (time() - $_SESSION["last_activity"] > 60)) {
+            # 最後にアクセスしてから1時間経過したとき
+            # セッション変数の初期化
+            $_SESSION = array();
+            # セッションファイルの破棄
+            session_destroy();
+            # セッションタイムアウトの通知、signin.phpへ遷移
+            echo "<script>alert('セッションタイムアウトしました');</script>";
+            echo "<script>location.href = '/sign_inup_form/signin.php';</script>";
+        }
+        # 最終アクセス時間の更新
+        $_SESSION["last_activity"] = time();
+    }
+
+    # 制作者:towa1204
+    # 更新日:2021/5/27
+    # 機能:ユーザのログインを行う
+    function session_login($uid) {
+        session_start();
+        session_regenerate_id(true);
+        // セッションファイルにユーザIDを格納する
+        $_SESSION['user_id'] = $uid;
+    }
+
+    # 制作者:towa1204
+    # 更新日:2021/5/27
+    # 機能:全ユーザのログアウトを行う
+    function session_logout() {
+        session_start();
+        # セッション変数の初期化
+        $_SESSION = array();
+
+        # セッションクッキーを削除
+        if (ini_get("session.use_cookies")) {
+            $params = session_get_cookie_params();
+            setcookie(session_name(), '', time() - 42000,
+                $params["path"], $params["domain"],
+                $params["secure"], $params["httponly"]
+            );
+        }
+
+        # セッションファイルの破棄
+        session_destroy();
+    }
+?>

--- a/index/common/user_session.php
+++ b/index/common/user_session.php
@@ -9,49 +9,68 @@
     # 更新日:2021/6/26
     # 機能:セッションの開始とセッションタイムアウトのチェックを行う
     function user_session_start() {
-        session_start();
-        if (isset($_SESSION["last_activity"]) && (time() - $_SESSION["last_activity"] > ONEHOUR)) {
-            # 最後にアクセスしてから1時間経過したとき
-            # セッション変数の初期化
-            $_SESSION = array();
-            # セッションファイルの破棄
-            session_destroy();
-            # セッションタイムアウトの通知、signin.phpへ遷移
-            echo "<script>alert('セッションタイムアウトしました');</script>";
-            echo "<script>location.href = '/sign_inup_form/signin.php';</script>";
+        try {
+            if (session_start() == false) {
+                throw new Exception("session did not work");
+            }
+            if (isset($_SESSION["last_activity"]) && (time() - $_SESSION["last_activity"] > ONEHOUR)) {
+                # 最後にアクセスしてから1時間経過したとき
+                # セッション変数の初期化
+                $_SESSION = array();
+                # セッションファイルの破棄
+                session_destroy();
+                # セッションタイムアウトの通知、signin.phpへ遷移
+                echo "<script>alert('セッションタイムアウトしました');</script>";
+                echo "<script>location.href = '/sign_inup_form/signin.php';</script>";
+            }
+            # 最終アクセス時間の更新
+            $_SESSION["last_activity"] = time();   
+            return true;
+        } catch(Exception $ex) {
+            return false;
         }
-        # 最終アクセス時間の更新
-        $_SESSION["last_activity"] = time();
     }
 
     # 制作者:towa1204
-    # 更新日:2021/5/27
+    # 更新日:2021/6/26
     # 機能:ユーザのログインを行う
     function session_login($uid) {
-        session_start();
-        session_regenerate_id(true);
-        // セッションファイルにユーザIDを格納する
-        $_SESSION['user_id'] = $uid;
+        try {
+            if (session_start() == false) {
+                throw new Exception("session did not work");
+            }
+            session_regenerate_id(true) == false;
+            // セッションファイルにユーザIDを格納する
+            $_SESSION['user_id'] = $uid;
+            return true;
+        } catch(Exception $ex) {
+            return false;
+        }
     }
 
     # 制作者:towa1204
     # 更新日:2021/6/26
     # 機能:全ユーザのログアウトを行う
     function session_logout() {
-        session_start();
-        # セッション変数の初期化
-        $_SESSION = array();
-
-        # セッションクッキーを削除
-        if (ini_get("session.use_cookies")) {
-            $params = session_get_cookie_params();
-            setcookie(session_name(), '', PAST,
-                $params["path"], $params["domain"],
-                $params["secure"], $params["httponly"]
-            );
+        try {
+            if (session_start() == false) {
+                throw new Exception("session did not work");
+            }
+            # セッション変数の初期化
+            $_SESSION = array();
+            # セッションクッキーを削除
+            if (ini_get("session.use_cookies")) {
+                $params = session_get_cookie_params();
+                setcookie(session_name(), '', PAST,
+                    $params["path"], $params["domain"],
+                    $params["secure"], $params["httponly"]
+                );
+            }
+            # セッションファイルの破棄
+            session_destroy();
+            return true;
+        } catch(Exception $ex) {
+            return false;
         }
-
-        # セッションファイルの破棄
-        session_destroy();
     }
 ?>

--- a/index/common/user_session.php
+++ b/index/common/user_session.php
@@ -6,7 +6,7 @@
     # 機能:セッションの開始とセッションタイムアウトのチェックを行う
     function user_session_start() {
         session_start();
-        if (isset($_SESSION["last_activity"]) && (time() - $_SESSION["last_activity"] > 60)) {
+        if (isset($_SESSION["last_activity"]) && (time() - $_SESSION["last_activity"] > 3600)) {
             # 最後にアクセスしてから1時間経過したとき
             # セッション変数の初期化
             $_SESSION = array();

--- a/index/sign_inup_form/php/match_data.php
+++ b/index/sign_inup_form/php/match_data.php
@@ -36,6 +36,11 @@
                 // user_idが一致　かつ　パスワードが一致　のとき
                 $result = true;
                 $massage = 'ログイン成功しました';
+                // ログイン成功したとわかったのでセッションIDを再生成する
+                session_start();
+                session_regenerate_id(true);
+                // セッションファイルにユーザIDを格納する
+                $_SESSION['user_id'] = $uid;
             }
         } catch(Exception $ex){
             // すでに同じIDのユーザが存在したときの処理

--- a/index/sign_inup_form/php/match_data.php
+++ b/index/sign_inup_form/php/match_data.php
@@ -13,6 +13,8 @@
     require_once('../../common/password_hash.php');
     require_once('./input_check.php');
 
+    require_once __DIR__ . '/../../common/user_session.php';
+
     // 入力値チェックを行う
     if (input_check($uid) && input_check($input_password)) {
         $db = new DBAccess();
@@ -36,11 +38,8 @@
                 // user_idが一致　かつ　パスワードが一致　のとき
                 $result = true;
                 $massage = 'ログイン成功しました';
-                // ログイン成功したとわかったのでセッションIDを再生成する
-                session_start();
-                session_regenerate_id(true);
-                // セッションファイルにユーザIDを格納する
-                $_SESSION['user_id'] = $uid;
+
+                session_login($uid);
             }
         } catch(Exception $ex){
             // すでに同じIDのユーザが存在したときの処理

--- a/index/sign_inup_form/signin.php
+++ b/index/sign_inup_form/signin.php
@@ -1,3 +1,6 @@
+<?php
+    session_start();
+?>
 <!DOCTYPE html>
 <html lang="ja">
 

--- a/index/sign_inup_form/signin.php
+++ b/index/sign_inup_form/signin.php
@@ -1,5 +1,6 @@
 <?php
-    session_start();
+    require_once __DIR__ . '/../common/user_session.php';
+    user_session_start();
 ?>
 <!DOCTYPE html>
 <html lang="ja">

--- a/index/sign_inup_form/signup.php
+++ b/index/sign_inup_form/signup.php
@@ -1,3 +1,6 @@
+<?php
+    session_start();
+?>
 <!DOCTYPE html>
 <html lang="ja">
 

--- a/index/sign_inup_form/signup.php
+++ b/index/sign_inup_form/signup.php
@@ -1,5 +1,6 @@
 <?php
-    session_start();
+    require_once __DIR__ . '/../common/user_session.php';
+    user_session_start();
 ?>
 <!DOCTYPE html>
 <html lang="ja">


### PR DESCRIPTION
### 追加した機能
- 未ログインおよびログインユーザのセッション処理
  - ログインユーザーは$_SESSION["user_id"]からユーザを識別
- 最後のページアクセスから1時間が経過した場合、セッションタイムアウトしsignin.phpへ遷移
  - すべてのユーザが対象

### php.iniの変更が必要
https://scrapbox.io/NT-Dentsu/%E3%83%90%E3%83%83%E3%82%AF%E3%82%A8%E3%83%B3%E3%83%89%E5%81%B4_%E8%A8%AD%E5%AE%9A%E5%A4%89%E6%9B%B4