### PR TITLE
close #72 ユーザーアイコンにセッション管理の実装

### DIFF
--- a/index/user_icon/js/user_icon_img.js
+++ b/index/user_icon/js/user_icon_img.js
@@ -3,30 +3,6 @@ $(function(){
     $.post({
         // 絶対パスで指定する
         url: '/user_icon/php/get_user_icon.php',
-        // ToDo:セッション情報からユーザーIDを受け取る(削除予定)
-        data: {
-            userId: "user1"
-        },
-        // 結果をjsonで受け取る
-        dataType: 'json',
-    }).done(function(result){
-        // imgタグのsrcを受け取ったパスで置き換える
-        $('.user_icon').children('img').attr('src', result.user_icon);
-    }).fail(function(XMLHttpRequest, textStatus, errorThrown){
-        // エラーメッセージを表示
-        alert(errorThrown);
-    })
-});
-
-// ToDo:テスト用ボタンクリック時(削除予定)
-$('#test_button').on('click', function(){
-    $.post({
-        // 絶対パスで指定する
-        url: '/user_icon/php/get_user_icon.php',
-        // セッション情報からユーザーIDを受け取る
-        data: {
-            userId: $('#test_id').val()
-        },
         // 結果をjsonで受け取る
         dataType: 'json',
     }).done(function(result){

--- a/index/user_icon/php/check_user_login.php
+++ b/index/user_icon/php/check_user_login.php
@@ -1,8 +1,7 @@
 <?php
-    // ToDo:共通関数として定義する
-
     // 自身のディレクトリからの絶対パスを指定する
     require_once __DIR__ . '/../../common/dbaccess.php';
+    require_once __DIR__ . '/../../common/user_session.php';
     // ヘッダー情報の明記
     header('Content-Type: application/json; charset=UTF-8');
 
@@ -15,13 +14,19 @@
     const VALUE_LOGOUT_STATUS = 'logout';
 
     try{
+        // セッションスタート
+        if(session_start() == false){
+            // セッションスタートが失敗したらスローする
+            throw new Exception('session did not work');
+        }
+
         // 戻り値を初期化(デフォルトはログアウト状態)
         $arrResult = array(
             KEY_LOGIN_STATUS => VALUE_LOGOUT_STATUS
         );
 
-        // ToDo:セッションからユーザーIDを取得する
-        $userId = filter_input(INPUT_POST, 'userId');
+        // セッションからユーザーIDを取得する
+        $userId = $_SESSION['user_id'];
         // ユーザーIDがNULLまたは空だった場合
         if(is_null($userId) || empty($userId)){
             // 結果をjsonにする
@@ -60,6 +65,6 @@
         $arrResult[KEY_LOGIN_STATUS] = VALUE_LOGOUT_STATUS;
 
         // 結果をjsonにする
-        echo json_encode($arrRecord);
+        echo json_encode($arrResult);
     }
 ?>

--- a/index/user_icon/php/get_user_icon.php
+++ b/index/user_icon/php/get_user_icon.php
@@ -1,6 +1,7 @@
 <?php
     // 自身のディレクトリからの絶対パスを指定する
     require_once __DIR__ . '/../../common/dbaccess.php';
+    require_once __DIR__ . '/../../common/user_session.php';
     // ヘッダー情報の明記
     header('Content-Type: application/json; charset=UTF-8');
 
@@ -12,8 +13,14 @@
     const KEY_USER_ICON = 'user_icon';
 
     try{
-        // ToDo:セッションからユーザーIDを取得する
-        $userId = filter_input(INPUT_POST, 'userId');
+        // セッションスタート
+        if(session_start() == false){
+            // セッションスタートが失敗したらスローする
+            throw new Exception('session did not work');
+        }
+
+        // セッションからユーザーIDを取得する
+        $userId = $_SESSION['user_id'];
         // ユーザーIDがNULLまたは空だった場合
         if(is_null($userId) || empty($userId)){
             // デフォルトユーザー名を設定する

--- a/index/user_icon/user_icon.php
+++ b/index/user_icon/user_icon.php
@@ -1,10 +1,8 @@
-<!-- ToDo:ここからテスト用のオブジェクト -->
-<form>
-    user_iconテスト用部品：<input type="text" id="test_id">
-    <button type="button" id="test_button">ユーザーID送信</button>
-</form>
-<!-- ToDo:ここまでテスト用のオブジェクト -->
-
+<?php
+    // セッションスタート
+    require_once __DIR__ . '/../common/user_session.php';
+    user_session_start();
+?>
 <!-- ユーザーアイコン -->
 <div class="user_icon">
     <!-- ユーザーがアップロードした画像を表示する -->


### PR DESCRIPTION
# 実装概要
- ログインしたユーザーのユーザーIDに紐づくユーザーアイコンを表示するように修正
- 不要なテストコードの削除