### PR TITLE
close #107 プロフィール画面の初期表示処理を実装

### DIFF
--- a/index/profile_form/css/profile.css
+++ b/index/profile_form/css/profile.css
@@ -20,8 +20,8 @@
 /* ユーザーアイコンの画像のCSS */
 .profile .user_icon img{
     /* 円形にする */
-    width:150px;
-    height:150px;
+    width:300px;
+    height:300px;
     border-radius:50%;
 }
 

--- a/index/profile_form/js/profile_init.js
+++ b/index/profile_form/js/profile_init.js
@@ -1,0 +1,30 @@
+// ページ読み込み時
+$(function(){
+    // テキストボックスを無効化する
+    document.getElementById('txt_user_name').disabled = 'disabled';
+    document.getElementById('txt_password').disabled = 'disabled';
+
+    $.post({
+        // 絶対パスで指定する
+        url: '/profile_form/php/get_profile_info.php',
+        // 結果をjsonで受け取る
+        dataType: 'json',
+    }).done(function(result){
+        if(result.exec_status == 'OK'){
+            // ユーザーマスタから取得した情報を設定する
+            document.getElementById('txt_user_name').value = result.user_name;
+            document.getElementById('txt_password').value = result.password;
+            // 画像はパスを置き換える
+            $('.user_icon').children('img').attr('src', result.user_icon);
+        }
+        else{
+            // エラーとなった旨を表示する
+            alert('エラーが発生したためメイン画面に戻ります');
+            // メイン画面に遷移させる
+            location.href = '/index.php'
+        }
+    }).fail(function(XMLHttpRequest, textStatus, errorThrown){
+        // エラーメッセージを表示
+        alert(errorThrown);
+    })
+});

--- a/index/profile_form/php/get_profile_info.php
+++ b/index/profile_form/php/get_profile_info.php
@@ -1,0 +1,76 @@
+<?php
+    // 自身のディレクトリからの絶対パスを指定する
+    require_once __DIR__ . '/../../common/dbaccess.php';
+    require_once __DIR__ . '/../../common/user_session.php';
+    // ヘッダー情報の明記
+    header('Content-Type: application/json; charset=UTF-8');
+
+    // SQLの実行結果
+    const STATUS_OK = 'OK';
+    const STATUS_NG = 'NG';
+    // 連想配列のキー
+    const KEY_STATUS = 'exec_status';
+    const KEY_USER_ID = 'user_id';
+    const KEY_USER_ICON = 'user_icon';
+    // デフォルトアイコンのパス
+    const DEFAULT_ICON_PATH = '/content/default_icon.jpg';
+
+    try{
+        // セッションスタート
+        if(session_start() == false){
+            // セッションスタートが失敗したらスローする
+            throw new Exception('session did not work');
+        }
+
+        // セッションからユーザーIDを取得する
+        $userId = $_SESSION['user_id'];
+        // ユーザーIDがNULLまたは空だった場合
+        if(is_null($userId) || empty($userId)){
+            // ユーザーIDを取得できなかったらスローする
+            throw new Exception('session did not work');
+        }
+
+        // DBアクセスクラスを生成
+        $clsDb = new DBAccess();
+        // 発行するクエリの定義
+        $query = 'select user_id, user_name, \'*****\' as password, user_icon from m_user where user_id = :user_id;';
+        // クエリを埋め込むパラメーターを設定
+        $param = array(
+            ':user_id' => $userId,
+        );
+
+        // DB接続
+        $pdo = $clsDb->connectDB();
+        // クエリを実行
+        $result = $clsDb->executePrepareSQL($pdo, $query, $param);
+        // 結果を1行取り出す
+        $arrRecord = $result->fetch(PDO::FETCH_ASSOC);
+        // DB切断
+        $clsDb->disconnectDB($pdo);
+
+        // 結果がNULLまたは空だった場合(主キーで判断)
+        if(is_null($arrRecord[KEY_USER_ID]) || empty($arrRecord[KEY_USER_ID])){
+            // 結果がNULLまたは空だったらスローする
+            throw new Exception('session did not work');
+        }
+        // ユーザーアイコンパスがNULLまたは空だった場合
+        if(is_null($arrRecord[KEY_USER_ICON]) || empty($arrRecord[KEY_USER_ICON])){
+            // デフォルトのパスを結果に格納する
+            $arrRecord[KEY_USER_ICON] = DEFAULT_ICON_PATH;
+        }
+
+        // ステータスをOKにする
+        $arrRecord[KEY_STATUS] = STATUS_OK;
+        // 結果をjsonにする
+        echo json_encode($arrRecord);
+    }
+    catch(Exception $ex){
+        // ステータスをNGにする
+        $arrRecord = array(
+            KEY_STATUS => STATUS_NG
+        );
+
+        // 結果をjsonにする
+        echo json_encode($arrRecord);
+    }
+?>

--- a/index/profile_form/php/get_profile_info.php
+++ b/index/profile_form/php/get_profile_info.php
@@ -32,7 +32,7 @@
 
         // DBアクセスクラスを生成
         $clsDb = new DBAccess();
-        // 発行するクエリの定義
+        // 発行するクエリの定義(\'はエスケープシーケンス)
         $query = 'select user_id, user_name, \'*****\' as password, user_icon from m_user where user_id = :user_id;';
         // クエリを埋め込むパラメーターを設定
         $param = array(

--- a/index/profile_form/profile.php
+++ b/index/profile_form/profile.php
@@ -54,22 +54,23 @@
                 <div class="profile">
                     <!-- ユーザーアイコン -->
                     <div class="user_icon">
+                        <img src="/content/default_icon.jpg" alt="user_icon">
                     </div>
                     <!-- ユーザー名 -->
                     <div class="user_name">
                         ユーザー名<br>
-                        <input type="text" name="user_name" maxlength="20">
+                        <input type="text" id="txt_user_name" maxlength="20">
                         <img src="/profile_form/images/edit_black_36dp.svg" alt="編集">
                     </div>
                     <!-- パスワード -->
                     <div class="password">
                         パスワード<br>
-                        <input type="text" name="password" maxlength="20">
+                        <input type="password" id="txt_password" maxlength="20">
                         <img src="/profile_form/images/edit_black_36dp.svg" alt="編集">
                     </div>
                     <!-- 保存ボタンとキャンセルボタン -->
                     <div class="profile_button">
-                        <button type="button" name="cancle" class="btn btn-danger">キャンセル</button>
+                        <button type="button" name="cancel" class="btn btn-danger">キャンセル</button>
                         <button type="button" name="update" class="btn btn-primary">保存</button>
                     </div>
                 </div>
@@ -84,7 +85,7 @@
         crossorigin="anonymous"></script>
     <!-- script -->
     <script src="/js/settings.js"></script>
-    <!-- <script src="./js/display_reflesh.js"></script> -->
+    <script src="/profile_form/js/profile_init.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
# 概要
- ログインユーザーIDから、「ユーザー名」「パスワード(※)」「ユーザーアイコン」を取得して、表示する処理を追加しました。
※パスワードは「*****」固定
- 今のところ正規手段で遷移できんので、すみませんが、動作検証時はprofile.phpへパスを直で指定するようにオナシャス。
- ちなみに、セッションからユーザーID取れない or 何らかの原因でSQLの結果がNULLになるようだったら、メイン画面に遷移させるようにしてる。