### PR TITLE
close #98 パネルの画像をトリミングしてきれいに表示する

### DIFF
--- a/index/css/grid_layout.css
+++ b/index/css/grid_layout.css
@@ -67,24 +67,14 @@
 }
 
 
-
-/* cssだけで画像をクリップする */
-/* rect(上, 右, 下, 左)	*/
-/* ボックスの左または上からの距離を「px」「%」などの単位を付けて、上→右→下→左の順にカンマで区切って指定します */
-.trim {
-    /* position: relative; */
-    box-sizing: border-box;
-}
-
+/* 画像周りの設定 */
 .panel img {
     /* position: absolute; */
     width: 100%;
-    /* padding: inherit; */
-    /*
-    top: 50%; /*親のtopから50% * /
-    left: 50%; /*親のleftから50% * /
-    transform: translateY(-50%) translateX(-50%); /*子要素自体の大きさを考慮 * /
-    */
+    height: 100%;
+
+    /* object-fitでトリミング */
+    object-fit: cover;
 }
 
 

--- a/index/index.php
+++ b/index/index.php
@@ -50,7 +50,7 @@
     <!-- タイトルバー -->
     <?php require_once __DIR__ . '/common/titlebar.php'; ?>
 
-    <div class="container-fluid">   
+    <div class="container-fluid">
         <div class="row">
             <!-- サイドバー -->
             <?php require_once __DIR__ . '/common/sidebar.php'; ?>
@@ -81,7 +81,13 @@
                 <div id="wrapper">
                     <div id="container">
                         <!-- グリッドのサイズ調整用 -->
-                        <div class="panel-wrap"></div>
+                        <div class="panel-wrap" style="grid-area: 1 / 1;"></div>
+                        <div class="panel-wrap" style="grid-area: 1 / 2;"></div>
+                        <div class="panel-wrap" style="grid-area: 1 / 3;"></div>
+                        <div class="panel-wrap" style="grid-area: 1 / 4;"></div>
+                        <div class="panel-wrap" style="grid-area: 2 / 1;"></div>
+                        <div class="panel-wrap" style="grid-area: 3 / 1;"></div>
+                        <div class="panel-wrap" style="grid-area: 4 / 1;"></div>
 
                         <!-- ここにパネルが追加される -->
                     </div>


### PR DESCRIPTION
object-fitを使ってパネル範囲に画像を収めた
トリミングするので画像の上下の一部が見切れることに注意
ついでに調整用パネルを増やしてブラウザによるgrid-layoutの動作の違いを少なくした