### PR TITLE
close #153 サイドバーとタイトルバーの不要ボタンを削除

### DIFF
--- a/index/app/kindle_copy/kindle_copy.php
+++ b/index/app/kindle_copy/kindle_copy.php
@@ -15,7 +15,7 @@
 <body>
     <!-- タイトルバー -->
     <?php require_once __DIR__ . '/../../common/titlebar.php'; ?>
-    
+
     <div class="container-fluid">
         <div class="row">
             <!-- サイドバー -->
@@ -24,19 +24,8 @@
             <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4" id="main">
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <h1 class="h2">Kindle Copy</h1>
-                    <!-- 上のボタン達 -->
-                    <div class="btn-toolbar mb-2 mb-md-0">
-                        <div class="btn-group mr-2">
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Share</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Export</button>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle">
-                            <span data-feather="calendar"></span>
-                            This week
-                        </button>
-                    </div>
                 </div>
-                
+
                 <div class="contents">
                     <p>Kindleでコピーしたテキストの空白の削除および改行を行うツールです。<br>
                     オプションで、引用元の削除も行えます。</p>
@@ -54,8 +43,8 @@
                     </div>
                     <button type="button" class="btn btn-outline-primary">Copy</button>
                 </div>
-            </main> 
-        </div>       
+            </main>
+        </div>
     </div>
 
     <!-- Optional JavaScript -->

--- a/index/common/sidebar.php
+++ b/index/common/sidebar.php
@@ -17,22 +17,7 @@
             <li class="nav-item">
                 <a class="nav-link" href="#">
                     <span data-feather="file"></span>
-                    Orders
-                </a>
-            </li>
-        </ul>
-
-        <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
-            <span>Saved reports</span>
-            <a class="d-flex align-items-center text-muted" href="#" aria-label="Add a new report">
-                <span data-feather="plus-circle"></span>
-            </a>
-        </h6>
-        <ul class="nav flex-column mb-2">
-            <li class="nav-item">
-                <a class="nav-link" href="#">
-                    <span data-feather="file-text"></span>
-                    Current month
+                    Contents
                 </a>
             </li>
         </ul>

--- a/index/index.php
+++ b/index/index.php
@@ -62,17 +62,6 @@
             <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4" id="main">
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <h1 class="h2">Home</h1>
-                    <!-- 上のボタン達 -->
-                    <div class="btn-toolbar mb-2 mb-md-0">
-                        <div class="btn-group mr-2">
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Share</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Export</button>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle">
-                            <span data-feather="calendar"></span>
-                            This week
-                        </button>
-                    </div>
                 </div>
                 <!-- ユーザーアイコン -->
                 <?php include("./user_icon/user_icon.php") ?>

--- a/index/panel_customize/panel_customize.php
+++ b/index/panel_customize/panel_customize.php
@@ -34,17 +34,6 @@
                 <div
                     class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <h1 class="h2">Panel Customize</h1>
-                    <!-- 上のボタン達 -->
-                    <div class="btn-toolbar mb-2 mb-md-0">
-                        <div class="btn-group mr-2">
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Share</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Export</button>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle">
-                            <span data-feather="calendar"></span>
-                            This week
-                        </button>
-                    </div>
                 </div>
 
                 <!-- <canvas class="my-4 w-100" id="myChart" width="900" height="380"></canvas> -->

--- a/index/profile_form/profile.php
+++ b/index/profile_form/profile.php
@@ -42,17 +42,6 @@
             <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4" id="main">
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <h1 class="h2">Profile</h1>
-                    <!-- 上のボタン達 -->
-                    <div class="btn-toolbar mb-2 mb-md-0">
-                        <div class="btn-group mr-2">
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Share</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary">Export</button>
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle">
-                            <span data-feather="calendar"></span>
-                            This week
-                        </button>
-                    </div>
                 </div>
                 <form method="post" name="profile_form" action="/profile_form/php/recive_profile_info.php" enctype="multipart/form-data">
                     <!-- プロフィール画面 -->


### PR DESCRIPTION
# 修正概要
- サイドバーの「SAVED POINTS」「Current Month」を削除
- サイドバーの「Orders」を「Contents」に変更
- タイトルバーの「Share」「Export」「This Week」を削除

- 修正前
![image](https://user-images.githubusercontent.com/60570891/147621743-46b18089-c1fc-49f2-8427-d251f45914ee.png)

- 修正後
![image](https://user-images.githubusercontent.com/60570891/147621777-feaa3680-3eea-423f-be83-825f64ceecea.png)

