### PR TITLE
close #147 bot810 キャンセルボタン押下時のバグ修正

### DIFF
--- a/index/panel_customize/js/btn_event.js
+++ b/index/panel_customize/js/btn_event.js
@@ -1,6 +1,6 @@
 /**
  * 制作者：bot810
- * 制作日：2022/01/08
+ * 制作日：2022/01/15
  * 保存ボタンとキャンセルボタンのイベントを設定
  */
 
@@ -27,11 +27,14 @@ cancel.click(function () {
     alert("cancel");
 
     // もとの奴に戻す
-    panelPromise.then((panelInfo) => {
-        console.log(panelInfo); // panelInfoにデータベースからの情報が入る
+    new Promise(function (resolve) {
+        resolve(panelInit()); // ここでデータベースから読み込み
+    })
+    .then((pInfo) => {
+        console.log(pInfo); // pInfoにデータベースからの情報が入る
         // 変更を反映させる
         containerEnpty();
-        panelInfo.forEach(containerAppend);
+        pInfo.forEach(containerAppend);
     });
 
 });

--- a/index/panel_customize/js/btn_event.js
+++ b/index/panel_customize/js/btn_event.js
@@ -1,6 +1,6 @@
 /**
  * 制作者：bot810
- * 制作日：2021/10/09
+ * 制作日：2022/01/08
  * 保存ボタンとキャンセルボタンのイベントを設定
  */
 
@@ -27,13 +27,12 @@ cancel.click(function () {
     alert("cancel");
 
     // もとの奴に戻す
-    panelInfo = new Array(); // 初期化
-    panelData.forEach(data => {
-        // 連想配列の形式(要素は順不同)
-        // {"panel_name" : <String>, "anchor_num" : <int>, "panel_size" : <int>, "content_link" : <String>, "content_image" : <String>}
-        // PanelInfoの引数
-        // (名前, 位置, 大きさ, 画像, ツールへのリンク)
-        panelInfo.push(data.panel_name, data.anchor_num, data.panel_size, data.content_image, data.content_link);
+    panelPromise.then((panelInfo) => {
+        console.log(panelInfo); // panelInfoにデータベースからの情報が入る
+        // 変更を反映させる
+        containerEnpty();
+        panelInfo.forEach(containerAppend);
     });
+
 });
 

--- a/index/panel_customize/js/div_control.js
+++ b/index/panel_customize/js/div_control.js
@@ -1,6 +1,6 @@
 /**
  * 制作者：bot810
- * 更新日：2021/11/27
+ * 更新日：2022/01/15
  * div要素の追加，変更をする．
  */
 
@@ -12,11 +12,11 @@ let text;
 // panelInfoはpanel_dataset_costomize.jsで定義されている
 // イベントを使ってクリック時の動作を制御する
 // イベント設定のためname属性にpanelを指定
-let panelInfo = new Array()
+// let panelInfo = new Array()
 panelPromise.then((data) => {
     console.log(data);
     data.forEach(containerAppend);
-    panelInfo = data;
+    // panelInfo = data;
 });
 
 // conttainerに子要素を追加する

--- a/index/panel_customize/js/panel_dataset_init_customize.js
+++ b/index/panel_customize/js/panel_dataset_init_customize.js
@@ -1,7 +1,7 @@
 /**
  * 制作者：bot810
  * 制作日：2021/07/22
- * 更新日：2022/01/08
+ * 更新日：2022/01/15
  * パネル関連の並びを定義
  * home画面とcoutomize画面で一部違いがあるため別ファイルとする
  */
@@ -30,8 +30,8 @@ function panelInit() {
         // 渡すデータ
         let panelInfo = new Array();
         // パネルデータをもとにパネルクラス作成
-        console.log("here");
-        console.log(panelData);
+        // console.log("here");
+        // console.log(panelData);
         panelData.forEach(data => {
             // 連想配列の形式(要素は順不同)
             // {"panel_name" : <String>, "anchor_num" : <int>, "panel_size" : <int>, "content_link" : <String>, "content_image" : <String>}

--- a/index/panel_customize/js/panel_dataset_init_customize.js
+++ b/index/panel_customize/js/panel_dataset_init_customize.js
@@ -1,7 +1,7 @@
 /**
  * 制作者：bot810
  * 制作日：2021/07/22
- * 更新日：2021/10/30
+ * 更新日：2022/01/08
  * パネル関連の並びを定義
  * home画面とcoutomize画面で一部違いがあるため別ファイルとする
  */
@@ -10,11 +10,6 @@
 // 初期値定義
 // home画面ではそのまま定義
 // costomize画面ではhome画面の値を利用
-// セッションストレージを利用
-// 参考サイト；https://qiita.com/uralogical/items/ade858ccfa164d164a3b
-
-//ストレージから読み込んだJSON文字列を配列に戻す(暫定)
-//let panelInfo = JSON.parse(sessionStorage.getItem("panelInfo"));
 
 // div_controlでの同期処理のためにPromise使う
 let panelPromise = new Promise(function (resolve) {


### PR DESCRIPTION
キャンセルボタン押下時にパネルデータが崩れる問題を修正
現在の動作はキャンセルボタンを押すとデータベースに記録されているパネル配置に戻すようになっている
そのため，保存ボタンを押した後だとキャンセルは効かないことに注意