### PR TITLE
close #178 bot810 プリセットデータをデータベースから読み込むように変更

### DIFF
--- a/doc/DB/QUERY/insert_preset_data.sql
+++ b/doc/DB/QUERY/insert_preset_data.sql
@@ -3,6 +3,7 @@
 # t_user_panel_infoテーブルにのみuser_idが/^preset.*$/のレコードがある
 # m_userのuser_id名において/^preset.*$/は既に予約されているものとする(入力チェックで弾く)
 
+# presetの作成
 # preset001の作成
 insert into t_user_panel_info values ("preset001", "size M hol", 0, 4);
 insert into t_user_panel_info values ("preset001", NULL, 1, NULL);
@@ -20,8 +21,59 @@ insert into t_user_panel_info values ("preset001", "size S", 12, 5);
 insert into t_user_panel_info values ("preset001", "size M hol", 13, 4);
 insert into t_user_panel_info values ("preset001", NULL, 14, NULL);
 insert into t_user_panel_info values ("preset001", "size S", 15, 5);
+# preset002の作成
+insert into t_user_panel_info values ("preset002", "size S", 0, 5);
+insert into t_user_panel_info values ("preset002", "size M hol", 1, 4);
+insert into t_user_panel_info values ("preset002", NULL, 2, NULL);
+insert into t_user_panel_info values ("preset002", "size S", 3, 5);
+insert into t_user_panel_info values ("preset002", "size M var", 4, 3);
+insert into t_user_panel_info values ("preset002", "size L", 5, 2);
+insert into t_user_panel_info values ("preset002", NULL, 6, NULL);
+insert into t_user_panel_info values ("preset002", "size M var", 7, 3);
+insert into t_user_panel_info values ("preset002", NULL, 8, NULL);
+insert into t_user_panel_info values ("preset002", NULL, 9, NULL);
+insert into t_user_panel_info values ("preset002", NULL, 10, NULL);
+insert into t_user_panel_info values ("preset002", NULL, 11, NULL);
+insert into t_user_panel_info values ("preset002", "size S", 12, 5);
+insert into t_user_panel_info values ("preset002", "size M hol", 13, 4);
+insert into t_user_panel_info values ("preset002", NULL, 14, NULL);
+insert into t_user_panel_info values ("preset002", "size S", 15, 5);
+# preset003の作成
+insert into t_user_panel_info values ("preset003", "size M var", 0, 3);
+insert into t_user_panel_info values ("preset003", "size S", 1, 5);
+insert into t_user_panel_info values ("preset003", "size L", 2, 2);
+insert into t_user_panel_info values ("preset003", NULL, 3, NULL);
+insert into t_user_panel_info values ("preset003", NULL, 4, NULL);
+insert into t_user_panel_info values ("preset003", "size S", 5, 5);
+insert into t_user_panel_info values ("preset003", NULL, 6, NULL);
+insert into t_user_panel_info values ("preset003", NULL, 7, NULL);
+insert into t_user_panel_info values ("preset003", "size L", 8, 2);
+insert into t_user_panel_info values ("preset003", NULL, 9, NULL);
+insert into t_user_panel_info values ("preset003", "size S", 10, 5);
+insert into t_user_panel_info values ("preset003", "size M var", 11, 3);
+insert into t_user_panel_info values ("preset003", NULL, 12, NULL);
+insert into t_user_panel_info values ("preset003", NULL, 13, NULL);
+insert into t_user_panel_info values ("preset003", "size S", 14, 5);
+insert into t_user_panel_info values ("preset003", NULL, 15, NULL);
+# preset004の作成
+insert into t_user_panel_info values ("preset004", "size L", 0, 2);
+insert into t_user_panel_info values ("preset004", NULL, 1, NULL);
+insert into t_user_panel_info values ("preset004", "size M hol", 2, 4);
+insert into t_user_panel_info values ("preset004", NULL, 3, NULL);
+insert into t_user_panel_info values ("preset004", NULL, 4, NULL);
+insert into t_user_panel_info values ("preset004", NULL, 5, NULL);
+insert into t_user_panel_info values ("preset004", "size S", 6, 5);
+insert into t_user_panel_info values ("preset004", "size M var", 7, 3);
+insert into t_user_panel_info values ("preset004", "size M var", 8, 3);
+insert into t_user_panel_info values ("preset004", "size S", 9, 5);
+insert into t_user_panel_info values ("preset004", "size S", 10, 5);
+insert into t_user_panel_info values ("preset004", NULL, 11, NULL);
+insert into t_user_panel_info values ("preset004", NULL, 12, NULL);
+insert into t_user_panel_info values ("preset004", "size M hol", 13, 4);
+insert into t_user_panel_info values ("preset004", NULL, 14, NULL);
+insert into t_user_panel_info values ("preset004", "size S", 15, 5);
 
-# preset001に使うパネル(m_panel)の作成
+# presetに使うパネル(m_panel)の作成
 insert into m_panel values ("size L", "/app/kindle_copy/kindle_copy.php", "/images/image_panel_L.jpg");
 insert into m_panel values ("size M hol", "/app/kindle_copy/kindle_copy.php", "/images/image_panel_M_h.jpg");
 insert into m_panel values ("size M var", "/app/kindle_copy/kindle_copy.php", "/images/image_panel_M_v.jpg");

--- a/index/panel_customize/js/panel_dataset_init_customize.js
+++ b/index/panel_customize/js/panel_dataset_init_customize.js
@@ -45,7 +45,32 @@ function panelInit() {
     });
 }
 
+// データベースから指定したプリセットパネルデータを読み込んみ，表示用に成型して返り値に渡す
+function panelPreset(presetID) {
+    // 同期処理
+    return get_presetdata(presetID)
+    .then((data) => {
+        // パネルデータをデータベースから取得
+        console.log(data.status);
+        console.log(data.array);
+        return data.array;
+    })
+    .then((panelData) => { // 上の処理が終わった後に実行
+        // 渡すデータ
+        let panelInfo = new Array();
+        // パネルデータをもとにパネルクラス作成
+        panelData.forEach(data => {
+            // 連想配列の形式(要素は順不同)
+            // {"panel_name" : <String>, "anchor_num" : <int>, "panel_size" : <int>, "content_link" : <String>, "content_image" : <String>}
+            // PanelInfoの引数
+            // (名前, 位置, 大きさ, 画像, ツールへのリンク)
+            panelInfo.push(new PanelInfo(data.panel_name, data.anchor_num, data.panel_size, data.content_image, data.content_link));
+        });
 
+        // 最終的にここの値が返る
+        return panelInfo;
+    });
+}
 
 // プリセットレイアウトの並びを定義
 let data01 = new Array();

--- a/index/panel_customize/js/panel_dataset_init_customize.js
+++ b/index/panel_customize/js/panel_dataset_init_customize.js
@@ -1,7 +1,7 @@
 /**
  * 制作者：bot810
  * 制作日：2021/07/22
- * 更新日：2022/01/15
+ * 更新日：2022/03/12
  * パネル関連の並びを定義
  * home画面とcoutomize画面で一部違いがあるため別ファイルとする
  */
@@ -18,6 +18,7 @@ let panelPromise = new Promise(function (resolve) {
 
 });
 
+// データベースから現在のユーザのパネルデータを読み込んみ，表示用に成型して返り値に渡す
 function panelInit() {
     // 同期処理
     return getUserPanels()

--- a/index/panel_customize/js/panel_dataset_init_customize.js
+++ b/index/panel_customize/js/panel_dataset_init_customize.js
@@ -74,54 +74,32 @@ function panelPreset(presetID) {
 }
 
 // プリセットレイアウトの並びを定義
-let data01 = new Array();
-let data02 = new Array();
-let data03 = new Array();
-let data04 = new Array();
-
 // プリセット01
-// (名前, 位置, 大きさ, 画像, ツールへのリンク)
-data01.push(new PanelInfo("size L", 4, 2, "/images/image_panel_L.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size M hol", 0, 4, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size M var", 3, 3, "/images/image_panel_M_v.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size M var", 6, 3, "/images/image_panel_M_v.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size M hol", 13, 4, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size S", 2, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size S", 11, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size S", 12, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data01.push(new PanelInfo("size S", 15, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-
+let data01;
+new Promise((resolve) => {
+    resolve(panelPreset("preset001"));
+}).then((data) => {
+    data01 = data;
+});
 // プリセット02
-// (名前, 位置, 大きさ, 画像, ツールへのリンク)
-data02.push(new PanelInfo("size L", 5, 2, "/images/image_panel_L.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size M hol", 1, 4, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size M hol", 13, 4, "/images/image_panel_M_v.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size M var", 4, 3, "/images/image_panel_M_v.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size M var", 7, 3, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size S", 0, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size S", 3, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size S", 12, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data02.push(new PanelInfo("size S", 15, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-
+let data02;
+new Promise((resolve) => {
+    resolve(panelPreset("preset002"));
+}).then((data) => {
+    data02 = data;
+});
 // プリセット03
-// (名前, 位置, 大きさ, 画像, ツールへのリンク)
-data03.push(new PanelInfo("size L", 2, 2, "/images/image_panel_L.jpg", "/panel_sample/panel_sample.html"));
-data03.push(new PanelInfo("size L", 8, 2, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data03.push(new PanelInfo("size M var", 0, 3, "/images/image_panel_M_v.jpg", "/panel_sample/panel_sample.html"));
-data03.push(new PanelInfo("size M var", 11, 3, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data03.push(new PanelInfo("size S", 1, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data03.push(new PanelInfo("size S", 5, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data03.push(new PanelInfo("size S", 10, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data03.push(new PanelInfo("size S", 14, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-
+let data03;
+new Promise((resolve) => {
+    resolve(panelPreset("preset003"));
+}).then((data) => {
+    data03 = data;
+});
 // プリセット04
-// (名前, 位置, 大きさ, 画像, ツールへのリンク)
-data04.push(new PanelInfo("size L", 0, 2, "/images/image_panel_L.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size M hol", 2, 4, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size M hol", 13, 4, "/images/image_panel_M_v.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size M var", 7, 3, "/images/image_panel_M_v.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size M var", 8, 3, "/images/image_panel_M_h.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size S", 6, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size S", 9, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size S", 10, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
-data04.push(new PanelInfo("size S", 15, 5, "/images/image_panel_S.jpg", "/panel_sample/panel_sample.html"));
+let data04;
+new Promise((resolve) => {
+    resolve(panelPreset("preset004"));
+}).then((data) => {
+    data04 = data;
+});
+

--- a/index/panel_customize/panel_customize.php
+++ b/index/panel_customize/panel_customize.php
@@ -157,6 +157,7 @@
 
     <!-- script -->
     <script src="./js/operate_paneldata.js"></script>
+    <script src="/common/js/get_presetdata.js"></script>
     <script src="./js/panel_class.js"></script>
     <script src="./js/panel_dataset_init_customize.js"></script>
     <script src="./js/panel_priset_layout.js"></script>


### PR DESCRIPTION
パネルカスタマイズ画面のpresetタブでプリセットを選択した際に利用するデータをDBから読み込むようにした
事前にDBに対して doc/DB/QUERY/insert_preset_data.sql を実行する必要がある