### PR TITLE
close #204 bot810 ドラッグしたパネルが背面になる現象の修正

### DIFF
--- a/index/common/css/grid_layout.css
+++ b/index/common/css/grid_layout.css
@@ -1,7 +1,7 @@
 /*
  * 制作者：bot810
  * 制作日：2021/11/27
- * 更新日：2022/06/10
+ * 更新日：2022/06/25
  * パネルの整列方法をMasonryからグリッドレイアウトへ変更
  */
 
@@ -37,7 +37,7 @@
     width: 100%;
     /* padding-bottom: 100%; */
     margin: 0px;
-    z-index: 1;
+    z-index: 10;
 }
 .panel-wrap::before {
     content: "";
@@ -57,7 +57,7 @@
     height: 100%;
     position: absolute;
     box-sizing: border-box;
-	z-index: 10;
+	z-index: 20;
 }
 
 .panel.S{

--- a/index/common/js/div_control.js
+++ b/index/common/js/div_control.js
@@ -1,7 +1,7 @@
 /**
  * 制作者：bot810
  * 作成日：2022/06/04
- * 更新日：
+ * 更新日：2022/06/25
  * div要素の追加，変更をする関数を定義．
  */
 
@@ -14,7 +14,7 @@ let text;
 function containerAppend(info) {
 
     // フラグによってコンテンツリンクの有無を変更
-    if(this == true){ // フラグがTrue
+    if(this == true){ // フラグがTrue(home画面)
         text = `
         <div class="${info.className}" style="grid-area: ${info.gridSize};">
             <a href="${info.toolLink}">
@@ -22,9 +22,9 @@ function containerAppend(info) {
             </a>
         </div>
         `;
-    }else{ // フラグがfalse
+    }else{ // フラグがfalse(customize画面)
         text = `
-        <div class="${info.className}" style="grid-area: ${info.gridSize};">
+        <div class="${info.className}" style="grid-area: ${info.gridSize}; z-index: 5;">
             <img src="${info.imageLink}" alt="" class="panelImg">
         </div>
         `;

--- a/index/panel_customize/js/customize_panel.js
+++ b/index/panel_customize/js/customize_panel.js
@@ -1,7 +1,7 @@
 /**
  * 作成者：bot810
  * 作成日:2022/01/29
- * 更新日:2022/05/14
+ * 更新日:2022/06/25
  * カスタマイズ画面のパネルタブ用js
  * パネルの配置とかレイアウトの変更とかする
  */
@@ -104,6 +104,8 @@ dragimg.draggable({
 dragimg.on("dragstart", function(event, ui){
     console.log("start event start");
     ui.helper.css('width', '10%');
+    /* .panelより前面にする */
+    ui.helper.css("z-index", "30");
     // pdata更新
     pdata = Array.from(global_panelInfo); // ディープコピー
     // pdataIndex更新


### PR DESCRIPTION
パネルカスタマイズ画面のpanelタブにおいてドラッグしたパネルが背面になってしまう現象の修正
z-indexの設定の不備によるもの

# 確認すること
- ちゃんとパネルが変更されるか
- 変なところにドラッグしたときに何も変化しないようになっているか

注意：キャンセルボタンのバグは健在なのでそのバグと間違えないように