### PR TITLE
close #208 キャンセルボタン押下時にコンテンツタブの表示がおかしい問題の修正

### DIFF
--- a/index/panel_customize/js/btn_event.js
+++ b/index/panel_customize/js/btn_event.js
@@ -43,6 +43,9 @@ cancel.click(function () {
 
         // customize_panel.jsのpdataの値を更新
         pdata = pInfo;
+
+        // コンテンツタブの中身を再設定
+        setContents();
     });
 
 });

--- a/index/panel_customize/js/customize_contents.js
+++ b/index/panel_customize/js/customize_contents.js
@@ -28,12 +28,8 @@ function pulldown(panelName) {
     return text;
 }
 
-
-// contentsタブクリック時の動作
-// クリックイベント設定
-$("#contents_tab").click(function () {
-    // 動作確認
-    console.log("contents Tab click");
+// コンテンツタブの中身を変更する処理
+function setContents() {
 
     // 中身を初期化
     $("#contents div").empty();
@@ -71,7 +67,16 @@ $("#contents_tab").click(function () {
         panelNum++;
     });
 
+}
 
+// contentsタブクリック時の動作
+// クリックイベント設定
+$("#contents_tab").click(function () {
+    // 動作確認
+    console.log("contents Tab click");
+
+    // コンテンツタブの中身を設定
+    setContents();
 });
 
 


### PR DESCRIPTION
コンテンツタブで設定する要素を変更したのちに，キャンセルボタンを押下したときにプルダウンリストの表示が現在の表示とは異なるものになる問題を修正

# 確認すること
- コンテンツタブで設定するコンテンツを変更できるか
- 変更したのち，保存ボタンを押さずにキャンセルボタンを押したときに元の表示に戻るか
- 元の表示に戻ったとき，変更したプルダウンリストが現在のコンテンツになっているか

# 注意?
#207 からブランチを切っているのでこちらを先にマージすること(こっちが後でもgithubが何とかしてくれるかな？)