### PR TITLE
close #193 サイドバーのコードを簡略化

### DIFF
--- a/index/common/css/dashboard.css
+++ b/index/common/css/dashboard.css
@@ -9,53 +9,42 @@ body {
 }
 
 /*
-* Sidebar
+* サイドバー
 */
-
 .sidebar {
     position: fixed;
     top: 0;
     bottom: 0;
     left: 0;
-    z-index: 100; /* Behind the navbar */
-    padding: 48px 0 0; /* Height of navbar */
+    z-index: 100;
+    padding: 48px 0 0;
     box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
 }
 
-@media (max-width: 767.98px) {
-    .sidebar {
-        top: 5rem;
-    }
-}
-
+/* スクロール時の張り付き設定 */
 .sidebar-sticky {
-    position: relative;
-    top: 0;
-    height: calc(100vh - 48px);
-    padding-top: .5rem;
+    position: sticky;
+    top: 4rem;
+    padding-top: 2rem;
     overflow-x: hidden;
-    overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
+    overflow-y: auto;
 }
 
-@supports ((position: -webkit-sticky) or (position: sticky)) {
-    .sidebar-sticky {
-        position: -webkit-sticky;
-        position: sticky;
-    }
-}
-
+/* サイドバーに表示する要素のスタイル */
 .sidebar .nav-link {
     font-weight: 500;
     color: #333;
 }
 
+.sidebar .nav-link.active {
+    color: #007bff;
+}
+
+
+/* サイドバーに表示する要素のアイコン */
 .sidebar .nav-link .feather {
     margin-right: 4px;
     color: #999;
-}
-
-.sidebar .nav-link.active {
-    color: #007bff;
 }
 
 .sidebar .nav-link:hover .feather,
@@ -63,41 +52,14 @@ body {
     color: inherit;
 }
 
-.sidebar-heading {
-    font-size: .75rem;
-    text-transform: uppercase;
-}
 
 /*
-* Navbar
+* タイトルバー
 */
-
 .navbar .navbar-brand {
     padding-top: 0.8%;
     padding-bottom: 0.8%;
     font-size: 28px;
     background-color: rgba(0, 0, 0, .25);
     box-shadow: inset -1px 0 0 rgba(0, 0, 0, .25);
-}
-
-.navbar .navbar-toggler {
-    top: .25rem;
-    right: 1rem;
-}
-
-.navbar .form-control {
-    padding: .75rem 1rem;
-    border-width: 0;
-    border-radius: 0;
-}
-
-.form-control-dark {
-    color: #fff;
-    background-color: rgba(255, 255, 255, .1);
-    border-color: rgba(255, 255, 255, .1);
-}
-
-.form-control-dark:focus {
-    border-color: transparent;
-    box-shadow: 0 0 0 3px rgba(255, 255, 255, .25);
 }

--- a/index/common/php/sidebar.php
+++ b/index/common/php/sidebar.php
@@ -1,27 +1,36 @@
-<nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
-    <!-- 横のボタンたち -->
-    <div class="sidebar-sticky pt-3">
+<!-- d-md-blockで、768px以上で要素を表示するようにする -->
+<nav id="sidebarMenu" class="sidebar col-md-3 col-lg-2 d-md-block bg-light collapse">
+    <!-- スクロール時に追従させる -->
+    <div class="sidebar-sticky">
         <ul class="nav flex-column">
+            <!-- メイン画面へのリンク -->
             <li class="nav-item">
                 <a class="nav-link" href="/index.php">
+                    <!-- 表示されるアイコンを設定する -->
                     <span data-feather="home"></span>
-                    Home <span class="sr-only">(current)</span>
+                    Home
                 </a>
             </li>
+            <!-- カスタマイズ画面へのリンク -->
             <li class="nav-item">
                 <a class="nav-link" href="/panel_customize/panel_customize.php">
+                    <!-- 表示されるアイコンを設定する -->
                     <span data-feather="layout"></span>
                     Customize
                 </a>
             </li>
+            <!-- プロフィール画面へのリンク -->
             <li class="nav-item">
                 <a class="nav-link" href="/profile_form/profile.php">
+                    <!-- 表示されるアイコンを設定する -->
                     <span data-feather="user"></span>
                     Profile
                 </a>
             </li>
+            <!-- ダミーリンク -->
             <li class="nav-item">
                 <a class="nav-link" href="#">
+                    <!-- 表示されるアイコンを設定する -->
                     <span data-feather="file"></span>
                     Contents
                 </a>


### PR DESCRIPTION
# 概要
* #193

# 変更内容
* サイドバーのコードの簡略化・サイドバー関係の不要なコードを削除。
* スクロール時に、「Home」や「Customize」が切れてしまっていたため、スクロールしても切れないように変更。
![image](https://user-images.githubusercontent.com/60570891/178105685-be140df3-b326-457f-bca0-7a93c8b63a49.png)


# 検証にあたって確認してほしいこと
* スクロールしても切れないように変更した箇所を除き、既存のサイドバーの動きから変わっていないこと。

# 補足
* 特になし